### PR TITLE
Added Support for Bower

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -9,5 +9,7 @@
     "examples",
     "docs",
     "tests"
-  ]
+  ],
+  "dependencies": {
+  }
 }


### PR DESCRIPTION
[Bower](http://bower.io/) is a client-side package manager, similar to `npm`.

In order to utilize the power of Bower, all a user has to do is inclue `cloudmine-js` in their own list of depdendencies.

``` json
{
  "name": "my-app-with-bower",
  "version": "0.0.1",
  "dependencies": {
    "cloudmine-js": "cloudmine/cloudmine-js#0.9.9"
  }
}
```

The `cloudmine/cloudmine-js#0.9.9` is shorthand for https://github.com/cloudmine/cloudmine-js.git

If you're interested in [registering your package](https://github.com/bower/bower#registering-packages), the format of the consumer's `bower.json` would change slightly:

``` json
{
  "name": "my-app-with-bower",
  "version": "0.0.1",
  "dependencies": {
    "cloudmine-js": "0.9.9"
  }
}
```

As you can see, the GitHub shorthand has been replaced by a [SemVer](http://semver.org/) number

All it would take is a single command (I haven't run it myself, as unregistering a package is currently a [manual process](https://github.com/bower/bower/issues/120), and I'd much rather leave the trigger pulling up to you guys)

``` console
bower register cloudmine-js https://github.com/cloudmine/cloudmine-js
```
